### PR TITLE
Fix Gradle space-assignment deprecation warnings

### DIFF
--- a/deployment/build.gradle
+++ b/deployment/build.gradle
@@ -23,7 +23,7 @@ tasks.register('license') {
 }
 
 tasks.register('installDist', Copy) {
-    duplicatesStrategy DuplicatesStrategy.EXCLUDE
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     dependsOn(parent.getTasksByName('installDist', true).findAll {
         // Don't create circular dependency or depend on built in openremote submodule apps
         it.project != project && !it.project.path.startsWith(":openremote:ui:app")

--- a/project.gradle
+++ b/project.gradle
@@ -102,7 +102,7 @@ if (project == rootProject) {
         idea.project.settings {
             compiler {
                 javac {
-                    javacAdditionalOptions "-parameters"
+                    javacAdditionalOptions = "-parameters"
                 }
             }
             runConfigurations {
@@ -150,10 +150,10 @@ repositories {
     }
     mavenCentral()
     maven {
-        url "https://pkgs.dev.azure.com/OpenRemote/OpenRemote/_packaging/OpenRemote/maven/v1"
+        url = "https://pkgs.dev.azure.com/OpenRemote/OpenRemote/_packaging/OpenRemote/maven/v1"
     }
     maven {
-        url "https://s01.oss.sonatype.org/content/repositories/snapshots"
+        url = "https://s01.oss.sonatype.org/content/repositories/snapshots"
     }
 }
 
@@ -165,8 +165,8 @@ apply plugin: 'idea'
 // Use the same output directories in IDE as in gradle
 idea {
     module {
-        outputDir file('build/classes/main')
-        testOutputDir file('build/classes/test')
+        outputDir = file('build/classes/main')
+        testOutputDir = file('build/classes/test')
         excludeDirs += file(".node")
         excludeDirs += file("node_modules")
         excludeDirs += file("dist")

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -24,9 +24,11 @@ test {
     useJUnitPlatform()
     testLogging {
         // set options for log level LIFECYCLE
-        events TestLogEvent.FAILED,
+        events = [
+                TestLogEvent.FAILED,
                 TestLogEvent.PASSED,
                 TestLogEvent.SKIPPED
+        ]
         exceptionFormat = TestExceptionFormat.FULL
         showExceptions = true
         showCauses = true
@@ -34,11 +36,13 @@ test {
 
         // set options for log level DEBUG and INFO
         debug {
-            events TestLogEvent.STARTED,
+            events = [
+                    TestLogEvent.STARTED,
                     TestLogEvent.FAILED,
                     TestLogEvent.PASSED,
                     TestLogEvent.SKIPPED,
                     TestLogEvent.STANDARD_ERROR
+            ]
             exceptionFormat = TestExceptionFormat.FULL
         }
         info.events = debug.events

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -27,10 +27,10 @@ test {
         events TestLogEvent.FAILED,
                 TestLogEvent.PASSED,
                 TestLogEvent.SKIPPED
-        exceptionFormat TestExceptionFormat.FULL
-        showExceptions true
-        showCauses true
-        showStackTraces true
+        exceptionFormat = TestExceptionFormat.FULL
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
 
         // set options for log level DEBUG and INFO
         debug {
@@ -39,7 +39,7 @@ test {
                     TestLogEvent.PASSED,
                     TestLogEvent.SKIPPED,
                     TestLogEvent.STANDARD_ERROR
-            exceptionFormat TestExceptionFormat.FULL
+            exceptionFormat = TestExceptionFormat.FULL
         }
         info.events = debug.events
         info.exceptionFormat = debug.exceptionFormat


### PR DESCRIPTION
Fixes the "Space-assignment syntax in Groovy DSL has been deprecated." warnings when using a newer Gradle version.

See: https://docs.gradle.org/8.12.1/userguide/upgrading_version_8.html#groovy_space_assignment_syntax