### PR TITLE
Fix CI/CD not using pull_request events

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,6 +13,9 @@ on:
       - '.ci_cd/**'
       - '**/*.md'
 
+  # PR
+  pull_request:
+
   # When a release is published
   release:
     types: [published]


### PR DESCRIPTION
When the pull_request event is not used only the push event is used causing backend tests not to run.

The backend tests in custom projects will only work after fixing https://github.com/openremote/openremote/issues/1710.