### PR TITLE
Restrict push event branches to main

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -5,7 +5,7 @@ on:
   # Push excluding tags and workflow changes
   push:
     branches:
-      - '**'
+      - 'main'
     tags-ignore:
       - '*.*'
     paths-ignore:


### PR DESCRIPTION
With https://github.com/openremote/custom-project/pull/18 PRs now trigger two workflows as both the `push` and `pull_request` events get triggered, see #19.
This makes the configuration similar to the [CI/CD workflow](https://github.com/openremote/openremote/blob/master/.github/workflows/ci_cd.yml) in the openremote repo.