### PR TITLE
Fix .DS_Store macOS file not ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ bin-release/
 .idea/
 .sts4-cache/
 .local/
-.DS_*/
+.DS_*
 apminsight-javaagent/
 console/iOS/DerivedData
 console/iOS/Pods


### PR DESCRIPTION
The .gitignore file doesn't exclude `.DS_Store` files because it checks for a directory instead of a file. Removing the `/` at the end solves this issue.