### PR TITLE
Point compose files to the deploy.yml file of tag 1.18.0

### DIFF
--- a/profile/dev-testing.yml
+++ b/profile/dev-testing.yml
@@ -4,11 +4,12 @@
 #
 # Please see profile/deploy.yml for configuration details for each service.
 #
-services:
+x-base: &base https://github.com/openremote/openremote.git#1.18.0:profile/deploy.yml
 
+services:
   keycloak:
     extends:
-      file: ../openremote/profile/deploy.yml
+      file: *base
       service: keycloak
     volumes:
       # Map custom themes
@@ -27,7 +28,7 @@ services:
 
   postgresql:
     extends:
-      file: ../openremote/profile/deploy.yml
+      file: *base
       service: postgresql
     volumes:
       - ../openremote/tmp:/storage

--- a/profile/dev-ui.yml
+++ b/profile/dev-ui.yml
@@ -4,6 +4,8 @@
 #
 # Please see profile/deploy.yml for configuration details for each service.
 #
+x-base: &base https://github.com/openremote/openremote.git#1.18.0:profile/deploy.yml
+
 volumes:
   manager-data:
 
@@ -11,7 +13,7 @@ services:
 
   keycloak:
     extends:
-      file: ../openremote/profile/deploy.yml
+      file: *base
       service: keycloak
     volumes:
       # Map custom themes
@@ -31,7 +33,7 @@ services:
 
   postgresql:
     extends:
-      file: ../openremote/profile/deploy.yml
+      file: *base
       service: postgresql
     volumes:
       - manager-data:/storage
@@ -41,7 +43,7 @@ services:
 
   manager:
     extends:
-      file: ../openremote/profile/deploy.yml
+      file: *base
       service: manager
     depends_on:
       postgresql:


### PR DESCRIPTION
### Description

This resolves the following issue:

- https://github.com/openremote/openremote/issues/1620

You can check the diff between these by running the following commands.

```sh
git switch main
cp profile/dev-testing.yml profile/testing.yml # make sure openremote is a submodule (or patch the compose file appropriately)
git cherry-pick bed5426609c457cbd2389d42269a8bf452aaee56
diff <(docker compose -f profile/testing.yml config | sort) <(docker compose -f profile/dev-testing.yml config | sort)
```

Resulting diff

```
60a61
> x-base: https://github.com/openremote/openremote.git#1.18.0:profile/deploy.yml
```

I would say this is an intermediate solution until we have OCI artifacts to point to.