### PR TITLE
Fix snapshot deployment dependencies

### DIFF
--- a/deployment/build.gradle
+++ b/deployment/build.gradle
@@ -30,8 +30,8 @@ tasks.register('license') {
 tasks.register('installDist', Copy) {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     dependsOn(parent.getTasksByName('installDist', true).findAll {
-        // Don't create circular dependency or depend on built in openremote submodule apps
-        it.project != project && !it.project.path.startsWith(":openremote:ui:app")
+        // Don't create circular dependency
+        it.project != project
     })
 
     into("$buildDir")
@@ -48,6 +48,6 @@ tasks.register('installDist', Copy) {
         // Don't include deps baked into the manager docker image
         exclude configurations.managerRuntime.resolvedConfiguration.resolvedArtifacts.collect {it.file.name }
         // Don't include any ui packaged JARs (used for dev purposes only)
-        exclude { (it.file.path.contains(".gradle")  || it.file.path.contains(".m2")) && it.file.path.contains("io.openremote.ui") }
+        exclude { (it.file.path.contains(".gradle") || it.file.path.contains(".m2")) && it.file.path.contains("io/openremote/ui") }
     }
 }


### PR DESCRIPTION
This fixes the issue that UI JARs are included in the custom project deployment when `openremoteVersion` is set to a SNAPSHOT version published locally. It is also no longer necessary to exclude `:openremote:ui:app` from the tasks because submodules are no longer used.