### PR TITLE
Use Gradle plugin and dependency version catalog configuration

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: "java-library"
+plugins {
+    id 'java-library'
+}
 
 dependencies {
     api project(":model")
-    api "io.openremote:openremote-agent:$openremoteVersion"
+    api libs.openremote.agent
 }
 
 tasks.register('installDist') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,11 @@
-// Configure version based on Git tags
-apply plugin: 'pl.allegro.tech.build.axion-release'
+import static org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS
+import static org.apache.tools.ant.taskdefs.condition.Os.isFamily
+
+plugins {
+    alias libs.plugins.axionRelease
+    alias libs.plugins.fileEncrypt apply false
+}
+
 scmVersion {
     releaseOnlyOnReleaseBranches = true
     releaseBranchNames = ['main']
@@ -23,7 +29,7 @@ allprojects {
 // When using encryption the the GFE_PASSWORD environment variable must be set or the build will fail
 // use ./gradlew encryptFiles to encrypt files
 
-//apply plugin: "com.cherryperry.gradle-file-encrypt"
+//pluginManager.apply(libs.plugins.fileEncrypt.get().pluginId)
 //gradleFileEncrypt {
 //    // files to encrypt
 //    plainFiles.from("deployment/manager/fcm.json")
@@ -44,7 +50,7 @@ allprojects {
 //        def plainFiles = project.getProperties().get("gradleFileEncrypt").plainFiles
 //        plainFiles.each { plainFile ->
 //            def args = []
-//            if (org.apache.tools.ant.taskdefs.condition.Os.isFamily(org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)) {
+//            if (isFamily(FAMILY_WINDOWS)) {
 //                args.add("cmd")
 //                args.add("/c")
 //            }

--- a/deployment/build.gradle
+++ b/deployment/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: "java-library"
+plugins {
+    id 'java-library'
+}
 
 configurations {
     managerRuntime
@@ -6,7 +8,7 @@ configurations {
 
 dependencies {
     api project(":setup")
-    managerRuntime "io.openremote:openremote-manager:$openremoteVersion"
+    managerRuntime libs.openremote.manager
 }
 
 tasks.register('license') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.parallel=true
 projectName = custom-project
 version = 1.0-SNAPSHOT
 
-openremoteVersion = 1.25.0
+# When updating the OpenRemote version, also update the version in gradle/libs.versions.toml
+openremoteVersion = 1.26.2
 
-jacksonVersion = 2.21.3
-testLoggerVersion = 4.0.0
+ideaExtPluginVersion = 1.4.1
 typescriptGeneratorVersion = 4.1.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,28 @@
+[versions]
+axionRelease = "1.21.2"
+fileEncrypt = "2.1.0"
+jackson = "2.21.4"
+openremote = "1.26.2"
+testLogger = "4.0.0"
+typescript-generator = "4.1.1"
+
+[libraries]
+jackson-datatype-jdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8", version.ref = "jackson" }
+jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
+jackson-module-parameter-names = { module = "com.fasterxml.jackson.module:jackson-module-parameter-names", version.ref = "jackson" }
+openremote-agent = { module = "io.openremote:openremote-agent", version.ref = "openremote" }
+openremote-container = { module = "io.openremote:openremote-container", version.ref = "openremote" }
+openremote-manager = { module = "io.openremote:openremote-manager", version.ref = "openremote" }
+openremote-model = { module = "io.openremote:openremote-model", version.ref = "openremote" }
+openremote-model-util = { module = "io.openremote:openremote-model-util", version.ref = "openremote" }
+openremote-test = { module = "io.openremote:openremote-test", version.ref = "openremote" }
+openremote-ui-insights = { module = "io.openremote.ui:openremote-insights", version.ref = "openremote" }
+openremote-ui-manager = { module = "io.openremote.ui:openremote-manager", version.ref = "openremote" }
+openremote-ui-shared = { module = "io.openremote.ui:openremote-shared", version.ref = "openremote" }
+openremote-ui-swagger = { module = "io.openremote.ui:openremote-swagger", version.ref = "openremote" }
+typescript-generator-core = { module = "cz.habarta.typescript-generator:typescript-generator-core", version.ref = "typescript-generator" }
+
+[plugins]
+axionRelease = { id = "pl.allegro.tech.build.axion-release", version.ref = "axionRelease" }
+fileEncrypt = { id = "io.openremote.com.cherryperry.gradle-file-encrypt", version.ref = "fileEncrypt" }
+testLogger = { id = "com.adarshr.test-logger", version.ref = "testLogger" }

--- a/manager/build.gradle
+++ b/manager/build.gradle
@@ -1,10 +1,12 @@
-apply plugin: "java-library"
+plugins {
+    id 'java-library'
+}
 
 dependencies {
     api project(":agent")
     api project(":model")
-    api "io.openremote:openremote-container:$openremoteVersion"
-    api "io.openremote:openremote-manager:$openremoteVersion"
+    api libs.openremote.container
+    api libs.openremote.manager
 }
 
 tasks.register('installDist') {

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,7 +1,9 @@
-apply plugin: "java-library"
+plugins {
+    id 'java-library'
+}
 
 dependencies {
-    api "io.openremote:openremote-model:$openremoteVersion"
+    api libs.openremote.model
 }
 
 tasks.register('installDist') {

--- a/project.gradle
+++ b/project.gradle
@@ -112,7 +112,7 @@ exit \$status
 
 // Configure Conditional plugins
 if (project == rootProject) {
-    apply plugin: "org.jetbrains.gradle.plugin.idea-ext"
+    pluginManager.apply('org.jetbrains.gradle.plugin.idea-ext')
 
     // Configure IDEA
     if (project.hasProperty("idea") && idea.project) {
@@ -180,10 +180,10 @@ repositories {
 }
 
 // Eclipse needs help
-apply plugin: "eclipse"
+pluginManager.apply('eclipse')
 
 // Intellij needs help
-apply plugin: 'idea'
+pluginManager.apply('idea')
 // Use the same output directories in IDE as in gradle
 idea {
     module {
@@ -312,23 +312,12 @@ def createTSGeneratorConfig(boolean outputAPIClient, String outputFileName, Proj
     }
 }
 
-def resolveTask(String path) {
-    tasks.getByPath(path)
-}
-
 def getYarnInstallTask() {
-    def customPackageJsonFile = Paths.get(rootProject.projectDir.path, "package.json").toFile()
-    if (!customPackageJsonFile.exists()) {
-        // No custom project yarn package.json so use standard openremote repo package.json
-        return resolveTask(":yarnInstall")
-    } else {
-        return tasks.getByPath(":yarnInstall")
-    }
+    tasks.getByPath(":yarnInstall")
 }
 
 
 ext {
-    resolveTask = this.&resolveTask
     getYarnInstallTask = this.&getYarnInstallTask
     createTSGeneratorConfigForClient = this.&createTSGeneratorConfigForClient
     createTSGeneratorConfigForModel = this.&createTSGeneratorConfigForModel

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,30 @@
+pluginManagement {
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id ==
+                    'io.openremote.com.cherryperry.gradle-file-encrypt') {
+                useModule(
+                        "com.github.openremote:GradleFileEncrypt:${requested.version}"
+                )
+            }
+        }
+    }
+
+    repositories {
+        gradlePluginPortal()
+        maven {
+            url = uri('https://jitpack.io')
+        }
+   }
+}
+
+// TODO: These plugins remain here because project.gradle imports their classes,
+// and version-catalog aliases cannot be used in settings.gradle. Move the related
+// configuration into convention plugins/build logic so their versions can be
+// managed through libs.versions.toml.
 plugins {
-    id "com.cherryperry.gradle-file-encrypt" version "2.0.3" apply false
-    id "org.jetbrains.gradle.plugin.idea-ext" version "1.2" apply false
     id 'cz.habarta.typescript-generator' version "$typescriptGeneratorVersion" apply false
-    id 'pl.allegro.tech.build.axion-release' version '1.21.1' apply false
+    id 'org.jetbrains.gradle.plugin.idea-ext' version "$ideaExtPluginVersion" apply false
 }
 
 rootProject.name = "$projectName"

--- a/setup/build.gradle
+++ b/setup/build.gradle
@@ -1,14 +1,16 @@
-apply plugin: "java-library"
+plugins {
+    id 'java-library'
+}
 
 dependencies {
     api project(":agent")
     api project(":model")
     api project(":manager")
 
-    implementation "io.openremote.ui:openremote-insights:$openremoteVersion"
-    implementation "io.openremote.ui:openremote-manager:$openremoteVersion"
-    implementation "io.openremote.ui:openremote-shared:$openremoteVersion"
-    implementation "io.openremote.ui:openremote-swagger:$openremoteVersion"
+    implementation libs.openremote.ui.insights
+    implementation libs.openremote.ui.manager
+    implementation libs.openremote.ui.shared
+    implementation libs.openremote.ui.swagger
 }
 
 tasks.register('installDist') {

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -2,17 +2,16 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
-    id 'com.adarshr.test-logger' version "$testLoggerVersion"
+    id 'java-library'
+    id 'groovy'
+    alias libs.plugins.testLogger
 }
-
-apply plugin: "java-library"
-apply plugin: "groovy"
 
 dependencies {
     api project(":manager")
     api project(":model")
     api project(":agent")
-    testImplementation "io.openremote:openremote-test:$openremoteVersion"
+    testImplementation libs.openremote.test
 }
 
 tasks.withType(Test).configureEach {

--- a/ui/app/custom-react/build.gradle
+++ b/ui/app/custom-react/build.gradle
@@ -6,7 +6,7 @@ tasks.register('clean') {
 
 tasks.register('installDist', Copy) {
     dependsOn npmBuild
-    mustRunAfter(resolveTask(":manager:installDist"))
+    mustRunAfter ":manager:installDist"
     from project.buildDir
     into "${project(':deployment').buildDir}/image/manager/app/${projectDir.name}"
 }

--- a/ui/app/custom/build.gradle
+++ b/ui/app/custom/build.gradle
@@ -6,7 +6,7 @@ tasks.register('clean') {
 
 tasks.register('installDist', Copy) {
     dependsOn npmBuild
-    mustRunAfter(resolveTask(":manager:installDist"))
+    mustRunAfter ":manager:installDist"
     from project.buildDir
     into "${project(':deployment').buildDir}/image/manager/app/${projectDir.name}"
 }

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,16 +1,16 @@
 afterEvaluate {
     // Add dependencies on model and rest typescript generation
     rootProject.getTasksByName('prepareUi', true).forEach {
-        it.dependsOn resolveTask(":ui:component:model:generateTypeScript"), resolveTask(":ui:component:rest:generateTypeScript")
+        it.dependsOn ":ui:component:model:generateTypeScript", ":ui:component:rest:generateTypeScript"
     }
     rootProject.getTasksByName('publishUi', true).forEach {
-        it.dependsOn resolveTask(":ui:component:model:generateTypeScript"), resolveTask(":ui:component:rest:generateTypeScript")
+        it.dependsOn ":ui:component:model:generateTypeScript", ":ui:component:rest:generateTypeScript"
     }
     rootProject.getTasksByName('npmBuild', true).forEach {
-        it.dependsOn resolveTask(":ui:component:model:generateTypeScript"), resolveTask(":ui:component:rest:generateTypeScript")
+        it.dependsOn ":ui:component:model:generateTypeScript", ":ui:component:rest:generateTypeScript"
     }
 }
 
 tasks.register('modelWatch') {
-    dependsOn resolveTask(":ui:component:model:build"), resolveTask(":ui:component:rest:build")
+    dependsOn ":ui:component:model:build", ":ui:component:rest:build"
 }

--- a/ui/component/model/build.gradle
+++ b/ui/component/model/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 dependencies {
-    compileOnly "io.openremote:openremote-model-util:$openremoteVersion"
+    compileOnly libs.openremote.model.util
     implementation project(":agent")
     implementation project(":model")
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-parameter-names:$jacksonVersion"
-    implementation "cz.habarta.typescript-generator:typescript-generator-core:$typescriptGeneratorVersion"
+    implementation libs.jackson.datatype.jdk8
+    implementation libs.jackson.datatype.jsr310
+    implementation libs.jackson.module.parameter.names
+    implementation libs.typescript.generator.core
 }
 
 generateTypeScript createTSGeneratorConfigForModel("src/model.ts", findProject(":model"))

--- a/ui/component/rest/build.gradle
+++ b/ui/component/rest/build.gradle
@@ -1,14 +1,16 @@
-apply plugin: "groovy"
-apply plugin: "cz.habarta.typescript-generator"
+plugins {
+    id 'groovy'
+    id 'cz.habarta.typescript-generator'
+}
 
 dependencies {
-    compileOnly "io.openremote:openremote-model-util:$openremoteVersion"
+    compileOnly libs.openremote.model.util
     implementation project(":agent")
     implementation project(":model")
-    implementation "cz.habarta.typescript-generator:typescript-generator-core:$typescriptGeneratorVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-parameter-names:$jacksonVersion"
+    implementation libs.typescript.generator.core
+    implementation libs.jackson.datatype.jdk8
+    implementation libs.jackson.datatype.jsr310
+    implementation libs.jackson.module.parameter.names
 }
 
 generateTypeScript createTSGeneratorConfigForClient("src/restclient.ts", new File("${project(":ui:component:model").projectDir}/src/typescript-generator-info.json"), project(":model"))
@@ -18,7 +20,7 @@ def resourceJavaFilesCount = countResourceJavaFiles()
 def generateTypeScriptTask = tasks.named("generateTypeScript") {
     // Work around typescript-generator exposing non-serializable configuration objects as Gradle task inputs.
     doNotTrackState("typescript-generator uses non-serializable task input types")
-    dependsOn resolveTask(":ui:component:model:generateTypeScript")
+    dependsOn ":ui:component:model:generateTypeScript"
     onlyIf { resourceJavaFilesCount > 0 }
     finalizedBy dummyRestClient
 }


### PR DESCRIPTION
- Replaced inline Gradle dependency and plugin version declarations with version catalog aliases.
- Centralized shared versions and coordinates in `gradle/libs.versions.toml`.
- Updated Gradle build scripts to use catalog-based plugin and dependency configuration more consistently.
- Simplified build configuration by removing redundant inline version declarations.
- Aligned the custom project build setup with the approach used in OpenRemote core.
- Removed `resolveTask` submodule left over.

See also: https://github.com/openremote/openremote/pull/3058