### PR TITLE
List failed tests in test summary

### DIFF
--- a/buildSrc/src/main/groovy/TestSummaryListener.groovy
+++ b/buildSrc/src/main/groovy/TestSummaryListener.groovy
@@ -4,21 +4,34 @@ import org.gradle.api.tasks.testing.TestResult
 
 class TestSummaryListener implements TestListener, Serializable {
 
+    private final List<String> failedTests = Collections.synchronizedList(new ArrayList<>())
+
     @Override
     void beforeSuite(TestDescriptor suite) {}
 
     @Override
     void afterSuite(TestDescriptor desc, TestResult result) {
-        if (desc.parent == null) {
-            def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
-            def startItem = '|  '
-            def endItem = '  |'
-            def repeatLength = startItem.length() + output.length() + endItem.length()
+        if (desc.parent != null) {
+            return
+        }
 
-            println '\n' +
-                    ('-' * repeatLength) + '\n' +
-                    startItem + output + endItem + '\n' +
-                    ('-' * repeatLength)
+        def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+        def startItem = '|  '
+        def endItem = '  |'
+        def repeatLength = startItem.length() + output.length() + endItem.length()
+
+        println '\n' +
+                ('-' * repeatLength) + '\n' +
+                startItem + output + endItem + '\n' +
+                ('-' * repeatLength)
+
+        def failures = new ArrayList<>(failedTests).sort()
+
+        if (!failures.empty) {
+            println '\nFailed tests:'
+            failures.each { failure ->
+                println "  - ${failure}"
+            }
         }
     }
 
@@ -27,6 +40,11 @@ class TestSummaryListener implements TestListener, Serializable {
 
     @Override
     void afterTest(TestDescriptor desc, TestResult result) {
+        if (result.resultType == TestResult.ResultType.FAILURE) {
+            def className = desc.className ?: desc.parent?.name ?: '<unknown>'
+            failedTests.add("${className} > ${desc.name}")
+        }
+
         println "${desc.className} > ${desc.name} took: ${(result.endTime - result.startTime)}ms"
     }
 }


### PR DESCRIPTION
Collect failed test names in `TestSummaryListener` and print them at the end of each test task. Use a synchronized collection because tests may execute in parallel, and sort the failures to keep the output deterministic.

Similar to openremote/openremote#3118