### PR TITLE
Ignore Spotless Apply commit with Git Blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Applied the initial repository-wide Spotless formatting
+0029b7fa6f785162a4dcb9f2c45f0e20025093a0


### PR DESCRIPTION
Prevents the repository-wide Spotless formatting commit (0029b7fa6f785162a4dcb9f2c45f0e20025093a0) of #12 from obscuring the original authorship in Git blame.