### PR TITLE
Enable Spotless formatting for Groovy files

### DIFF
--- a/buildSrc/src/main/groovy/TestSummaryListener.groovy
+++ b/buildSrc/src/main/groovy/TestSummaryListener.groovy
@@ -22,47 +22,47 @@ import org.gradle.api.tasks.testing.TestResult
 
 class TestSummaryListener implements TestListener, Serializable {
 
-    private final List<String> failedTests = Collections.synchronizedList(new ArrayList<>())
+  private final List<String> failedTests = Collections.synchronizedList(new ArrayList<>())
 
-    @Override
-    void beforeSuite(TestDescriptor suite) {}
+  @Override
+  void beforeSuite(TestDescriptor suite) {}
 
-    @Override
-    void afterSuite(TestDescriptor desc, TestResult result) {
-        if (desc.parent != null) {
-            return
-        }
-
-        def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
-        def startItem = '|  '
-        def endItem = '  |'
-        def repeatLength = startItem.length() + output.length() + endItem.length()
-
-        println '\n' +
-                ('-' * repeatLength) + '\n' +
-                startItem + output + endItem + '\n' +
-                ('-' * repeatLength)
-
-        def failures = new ArrayList<>(failedTests).sort()
-
-        if (!failures.empty) {
-            println '\nFailed tests:'
-            failures.each { failure ->
-                println "  - ${failure}"
-            }
-        }
+  @Override
+  void afterSuite(TestDescriptor desc, TestResult result) {
+    if (desc.parent != null) {
+      return
     }
 
-    @Override
-    void beforeTest(TestDescriptor desc) {}
+    def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+    def startItem = '|  '
+    def endItem = '  |'
+    def repeatLength = startItem.length() + output.length() + endItem.length()
 
-    @Override
-    void afterTest(TestDescriptor desc, TestResult result) {
-        if (result.resultType == TestResult.ResultType.FAILURE) {
-            def className = desc.className ?: desc.parent?.name ?: '<unknown>'
-            failedTests.add("${className} > ${desc.name}")
-        }
+    println '\n' +
+            ('-' * repeatLength) + '\n' +
+            startItem + output + endItem + '\n' +
+            ('-' * repeatLength)
 
-        println "${desc.className} > ${desc.name} took: ${(result.endTime - result.startTime)}ms"
+    def failures = new ArrayList<>(failedTests).sort()
+
+    if (!failures.empty) {
+      println '\nFailed tests:'
+      failures.each { failure ->
+        println "  - ${failure}"
+      }
     }
+  }
+
+  @Override
+  void beforeTest(TestDescriptor desc) {}
+
+  @Override
+  void afterTest(TestDescriptor desc, TestResult result) {
+    if (result.resultType == TestResult.ResultType.FAILURE) {
+      def className = desc.className ?: desc.parent?.name ?: '<unknown>'
+      failedTests.add("${className} > ${desc.name}")
+    }
+
+    println "${desc.className} > ${desc.name} took: ${(result.endTime - result.startTime)}ms"
+  }
 }

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -95,9 +95,10 @@ spotless {
     endWithNewline()
   }
 
-  // Groovy files are not yet formatted because some use '::' operations which greclipse currently cannot handle
   groovy {
     target backendTarget(['**/*.groovy'])
+    toggleOffOn()
+    greclipse().configFile(rootProject.file('tools/spotless/greclipse-google.properties'))
     licenseHeaderFile(rootProject.file('tools/spotless/openremote-license-header.txt'), blockCommentLicenseDelimiter)
     trimTrailingWhitespace()
     endWithNewline()

--- a/test/src/test/groovy/org/openremote/test/custom/CustomTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/custom/CustomTest.groovy
@@ -30,34 +30,34 @@ import spock.util.concurrent.PollingConditions
 
 class CustomTest extends Specification implements ManagerContainerTrait {
 
-    def "Check custom agent and protocol"() {
+  def "Check custom agent and protocol"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 1)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 1)
 
-        when: "the container starts"
-        def serverPort = findEphemeralPort()
-        def container = startContainer(defaultConfig(serverPort), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+    when: "the container starts"
+    def serverPort = findEphemeralPort()
+    def container = startContainer(defaultConfig(serverPort), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
 
-        then: "the container should be running"
-        conditions.eventually {
-            assert container.isRunning()
-        }
+    then: "the container should be running"
+    conditions.eventually {
+      assert container.isRunning()
+    }
 
-        when: "a custom agent asset is added"
-        def agent = new CustomAgent("Test Agent")
+    when: "a custom agent asset is added"
+    def agent = new CustomAgent("Test Agent")
             .setRealm(Constants.MASTER_REALM)
             .setOption(CustomAgent.Option.TWO)
 
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
 
-        then: "the agent should be started"
-        conditions.eventually {
-            assert agentService.protocolInstanceMap.get(agent.id) != null
-            assert (agentService.protocolInstanceMap.get(agent.id) as CustomProtocol).running
-        }
+    then: "the agent should be started"
+    conditions.eventually {
+      assert agentService.protocolInstanceMap.get(agent.id) != null
+      assert (agentService.protocolInstanceMap.get(agent.id) as CustomProtocol).running
     }
+  }
 }


### PR DESCRIPTION
## Description

This enables GrEclipse formatting for Groovy files as part of the Spotless configuration.
The second commit applies Spotless formatting to the Groovy files.

### Merge

The two commits should preferably remain separate:

1. Enable Spotless formatting for Groovy files — functional/configuration changes required to enable formatting.
2. Format Groovy files — formatting-only changes.

To preserve this separation, the PR should preferably be rebased/merged with the merge queue temporarily disabled rather than squashed.

After merging, the resulting SHA of the Format Groovy files commit can be added to [`.git-blame-ignore-revs`](https://github.com/openremote/custom-project/blob/master/.git-blame-ignore-revs), so the repository-wide formatting changes do not interfere with `git blame`.

Similar to https://github.com/openremote/openremote/pull/3215